### PR TITLE
Removal of adata preprocessing

### DIFF
--- a/generate_simulate_data/processing_data.ipynb
+++ b/generate_simulate_data/processing_data.ipynb
@@ -226,8 +226,8 @@
     "    library_id = \"tissue\"\n",
     "    adata.uns[spatial_key] = {library_id: {}}\n",
     "    \n",
-    "    sc.pp.normalize_total(adata)\n",
-    "    sc.pp.log1p(adata)\n",
+    "    #sc.pp.normalize_total(adata)\n",
+    "    #sc.pp.log1p(adata)\n",
     "    \n",
     "    adata.write_h5ad(f'{input_dir}/{dataset}.h5ad')"
    ]


### PR DESCRIPTION
Hi, I'm currently working on improving GPcounts and found that removal of `sc.pp.log1p(adata)` would result in better model performance. This is especially true for lower sigma values and could be possibly due to the logarithm decreasing the dispersion of the counts that are sampled from poisson distribution.

Additionally, we noticed a bug when generating scales for the use of GPcounts. When setting the family parameter of `smf.glm()` it should be set to `sm.families.NegativeBinomial(sm.families.links.identity())).fit()` instead of `sm.families.NegativeBinomial(sm.families.links.log())).fit()`. This fixes the previous errors where most real data counts could not be fitted.

These changes have been edited in the fork accompanying this pull request. I eagerly await for your response.